### PR TITLE
Fix some minor build script issues.

### DIFF
--- a/bcap_service/CMakeLists.txt
+++ b/bcap_service/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bcap_service)
 
 find_package(catkin REQUIRED COMPONENTS
+  bcap_core
+  message_generation
   roscpp
   std_msgs
-  message_generation
-  bcap_core
 )
 
 add_message_files(
@@ -26,7 +26,7 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES bcap_service
-  CATKIN_DEPENDS roscpp std_msgs message_runtime
+  CATKIN_DEPENDS message_runtime roscpp std_msgs
   DEPENDS bcap_core
 )
 

--- a/bcap_service/package.xml
+++ b/bcap_service/package.xml
@@ -9,12 +9,12 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>bcap_core</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>bcap_core</build_depend>
+  <run_depend>bcap_core</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>bcap_core</run_depend>
 </package>

--- a/bcap_service_test/CMakeLists.txt
+++ b/bcap_service_test/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bcap_service_test)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
   bcap_service
+  roscpp
 )
 
 catkin_package(

--- a/bcap_service_test/package.xml
+++ b/bcap_service_test/package.xml
@@ -9,7 +9,7 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>bcap_service</build_depend>
+  <build_depend>roscpp</build_depend>
   <run_depend>roscpp</run_depend>
 </package>

--- a/denso_robot_bringup/CMakeLists.txt
+++ b/denso_robot_bringup/CMakeLists.txt
@@ -18,4 +18,4 @@ file(GLOB prgs RELATIVE ${PROJECT_SOURCE_DIR} "scripts/*.py")
 foreach(prg ${prgs})
    catkin_install_python(PROGRAMS ${prg}
       DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-endforeach(prg)
+endforeach()

--- a/denso_robot_control/CMakeLists.txt
+++ b/denso_robot_control/CMakeLists.txt
@@ -2,22 +2,22 @@ cmake_minimum_required(VERSION 2.8.3)
 project(denso_robot_control)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  std_msgs
-  hardware_interface
-  joint_limits_interface
-  transmission_interface
-  controller_manager
   bcap_core
   bcap_service
+  controller_manager
   denso_robot_core
+  hardware_interface
+  joint_limits_interface
+  roscpp
+  std_msgs
+  transmission_interface
 )
 
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs
-    hardware_interface joint_limits_interface
-    transmission_interface controller_manager
-    bcap_service denso_robot_core
+  CATKIN_DEPENDS bcap_service controller_manager
+    denso_robot_core hardware_interface
+    joint_limits_interface roscpp std_msgs
+    transmission_interface
   DEPENDS bcap_core
 )
 

--- a/denso_robot_control/package.xml
+++ b/denso_robot_control/package.xml
@@ -9,22 +9,22 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>joint_limits_interface</build_depend>
-  <build_depend>transmission_interface</build_depend>
-  <build_depend>controller_manager</build_depend>
   <build_depend>bcap_core</build_depend>
   <build_depend>bcap_service</build_depend>
+  <build_depend>controller_manager</build_depend>
   <build_depend>denso_robot_core</build_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>hardware_interface</run_depend>
-  <run_depend>joint_limits_interface</run_depend>
-  <run_depend>transmission_interface</run_depend>
-  <run_depend>controller_manager</run_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>joint_limits_interface</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>transmission_interface</build_depend>
   <run_depend>bcap_core</run_depend>
   <run_depend>bcap_service</run_depend>
+  <run_depend>controller_manager</run_depend>
   <run_depend>denso_robot_core</run_depend>
+  <run_depend>hardware_interface</run_depend>
+  <run_depend>joint_limits_interface</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>transmission_interface</run_depend>
 </package>

--- a/denso_robot_core/CMakeLists.txt
+++ b/denso_robot_core/CMakeLists.txt
@@ -2,41 +2,43 @@ cmake_minimum_required(VERSION 2.8.3)
 project(denso_robot_core)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  std_msgs
-  message_generation
   actionlib
   actionlib_msgs
   bcap_core
   bcap_service
+  message_generation
+  roscpp
+  std_msgs
 )
 
 add_message_files(
   FILES
-  Joints.msg
   ExJoints.msg
+  Joints.msg
   PoseData.msg
 )
 
 add_action_files(
   FILES
-  MoveString.action
-  MoveValue.action
   DriveString.action
   DriveValue.action
+  MoveString.action
+  MoveValue.action
 )
 
 generate_messages(
   DEPENDENCIES
-  std_msgs
   actionlib_msgs
+  std_msgs
 )
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES denso_robot_core
-  CATKIN_DEPENDS roscpp std_msgs message_runtime
-    actionlib actionlib_msgs bcap_service
+  CATKIN_DEPENDS actionlib
+    actionlib_msgs bcap_service
+    message_runtime roscpp
+    std_msgs
   DEPENDS bcap_core
 )
 
@@ -54,14 +56,14 @@ link_directories(
 )
 
 add_library(denso_robot_core
-  src/denso_robot_core.cpp
+  src/denso_base.cpp
   src/denso_controller.cpp
   src/denso_controller_rc8.cpp
   src/denso_robot.cpp
+  src/denso_robot_core.cpp
   src/denso_robot_rc8.cpp
   src/denso_task.cpp
   src/denso_variable.cpp
-  src/denso_base.cpp
   src/tinyxml2.cpp
 )
 
@@ -69,14 +71,14 @@ add_dependencies(denso_robot_core
   ${PROJECT_NAME}_generate_messages_cpp)
 
 add_executable(denso_robot_core_exec
-  src/denso_robot_core.cpp
+  src/denso_base.cpp
   src/denso_controller.cpp
   src/denso_controller_rc8.cpp
   src/denso_robot.cpp
+  src/denso_robot_core.cpp
   src/denso_robot_rc8.cpp
   src/denso_task.cpp
   src/denso_variable.cpp
-  src/denso_base.cpp
   src/tinyxml2.cpp
 )
 
@@ -114,4 +116,4 @@ install(DIRECTORY include/${PROJECT_NAME}/
 foreach(dir launch config)
    install(DIRECTORY ${dir}
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-endforeach(dir)
+endforeach()

--- a/denso_robot_core/package.xml
+++ b/denso_robot_core/package.xml
@@ -9,18 +9,18 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>bcap_core</build_depend>
   <build_depend>bcap_service</build_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>bcap_core</run_depend>
   <run_depend>bcap_service</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
 </package>

--- a/denso_robot_core_test/CMakeLists.txt
+++ b/denso_robot_core_test/CMakeLists.txt
@@ -2,15 +2,15 @@ cmake_minimum_required(VERSION 2.8.3)
 project(denso_robot_core_test)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  std_msgs
   actionlib
   bcap_core
   denso_robot_core
+  roscpp
+  std_msgs
 )
 
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs actionlib
+  CATKIN_DEPENDS actionlib roscpp std_msgs
 )
 
 ###########

--- a/denso_robot_core_test/package.xml
+++ b/denso_robot_core_test/package.xml
@@ -9,14 +9,14 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>bcap_core</build_depend>
   <build_depend>denso_robot_core</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>actionlib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>actionlib</run_depend>
 
   <export>
 

--- a/denso_robot_descriptions/CMakeLists.txt
+++ b/denso_robot_descriptions/CMakeLists.txt
@@ -14,4 +14,4 @@ file(GLOB descs RELATIVE ${PROJECT_SOURCE_DIR} "*_description")
 foreach(dir ${descs})
    install(DIRECTORY ${dir}
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-endforeach(dir)
+endforeach()

--- a/denso_robot_gazebo/CMakeLists.txt
+++ b/denso_robot_gazebo/CMakeLists.txt
@@ -13,4 +13,4 @@ catkin_package()
 foreach(dir launch worlds)
    install(DIRECTORY ${dir}
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-endforeach(dir)
+endforeach()

--- a/denso_robot_gazebo/package.xml
+++ b/denso_robot_gazebo/package.xml
@@ -9,8 +9,8 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>gazebo_ros_pkgs</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
+  <run_depend>gazebo_ros_pkgs</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
   

--- a/denso_robot_moveit_config/CMakeLists.txt
+++ b/denso_robot_moveit_config/CMakeLists.txt
@@ -13,4 +13,4 @@ catkin_package()
 foreach(dir launch config)
    install(DIRECTORY ${dir}
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-endforeach(dir)
+endforeach()

--- a/denso_robot_moveit_config/package.xml
+++ b/denso_robot_moveit_config/package.xml
@@ -16,14 +16,12 @@
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>moveit_planners_ompl</run_depend>
+  <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
 
 </package>

--- a/denso_robot_ros/package.xml
+++ b/denso_robot_ros/package.xml
@@ -12,13 +12,13 @@
   <run_depend>bcap_core</run_depend>
   <run_depend>bcap_service</run_depend>
   <run_depend>bcap_service_test</run_depend>
+  <run_depend>denso_robot_bringup</run_depend>
+  <run_depend>denso_robot_control</run_depend>
   <run_depend>denso_robot_core</run_depend>
   <run_depend>denso_robot_core_test</run_depend>
-  <run_depend>denso_robot_control</run_depend>
-  <run_depend>denso_robot_gazebo</run_depend>
   <run_depend>denso_robot_descriptions</run_depend>
+  <run_depend>denso_robot_gazebo</run_depend>
   <run_depend>denso_robot_moveit_config</run_depend>
-  <run_depend>denso_robot_bringup</run_depend>
 
   <export>
     <metapackage />


### PR DESCRIPTION
Addresses some minor issues with the `CMakeLists.txt`s in the pkgs.

No functional changes.

There are still some left:
```shell
$ catkin_lint -W2 .
bcap_core: warning: include paths 'include/bcap_core/TPComm' and 'include' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/TPComm' and 'include/bcap_core' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/bCAPServer' and 'include' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/bCAPServer' and 'include/bcap_core' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/RACString' and 'include' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/RACString' and 'include/bcap_core' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/bCAPClient' and 'include' are ambiguous
bcap_core: warning: include paths 'include/bcap_core/bCAPClient' and 'include/bcap_core' are ambiguous
bcap_core: warning: include paths 'include/bcap_core' and 'include' are ambiguous
bcap_core: warning: include path 'include' is exported but not used for the build
bcap_core: CMakeLists.txt(16): notice: global variable '_USE_LINUX_API' should contain project name
bcap_core: CMakeLists.txt(17): notice: global variable '_DN_USE_VARIANT_API' should contain project name
bcap_core: CMakeLists.txt(18): notice: global variable '_DN_USE_BSTR_API' should contain project name
bcap_core: CMakeLists.txt(49): notice: list of source files should be sorted
bcap_core: CMakeLists.txt(65): notice: list of source files should be sorted
bcap_core: CMakeLists.txt(81): notice: list of source files should be sorted
bcap_core: CMakeLists.txt(106): notice: list TARGETS should be sorted
bcap_core: CMakeLists.txt(113): notice: use ${PROJECT_NAME} instead of 'bcap_core'
bcap_service: CMakeLists.txt(26): error: catkin_package() lists 'bcap_core' as system package but it is not
bcap_service: warning: include paths 'include/bcap_service' and 'include' are ambiguous
bcap_service: warning: include path 'include' is exported but not used for the build
bcap_service: CMakeLists.txt(42): warning: use of link_directories() is strongly discouraged
bcap_service: CMakeLists.txt(26): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(46): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(49): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(52): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(55): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(58): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(63): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service: CMakeLists.txt(72): notice: use ${PROJECT_NAME} instead of 'bcap_service'
bcap_service_test: CMakeLists.txt(21): notice: use ${PROJECT_NAME} instead of 'bcap_service_test'
bcap_service_test: CMakeLists.txt(24): notice: use ${PROJECT_NAME} instead of 'bcap_service_test'
bcap_service_test: CMakeLists.txt(32): notice: use ${PROJECT_NAME} instead of 'bcap_service_test'
denso_robot_control: CMakeLists.txt(16): error: catkin_package() lists 'bcap_core' as system package but it is not
denso_robot_control: CMakeLists.txt(33): warning: use of link_directories() is strongly discouraged
denso_robot_control: CMakeLists.txt(37): notice: use ${PROJECT_NAME} instead of 'denso_robot_control'
denso_robot_control: CMakeLists.txt(42): notice: use ${PROJECT_NAME} instead of 'denso_robot_control'
denso_robot_control: CMakeLists.txt(51): notice: use ${PROJECT_NAME} instead of 'denso_robot_control'
denso_robot_core: CMakeLists.txt(35): error: catkin_package() lists 'bcap_core' as system package but it is not
denso_robot_core: warning: include paths 'include/denso_robot_core' and 'include' are ambiguous
denso_robot_core: warning: include path 'include' is exported but not used for the build
denso_robot_core: CMakeLists.txt(54): warning: use of link_directories() is strongly discouraged
denso_robot_core: CMakeLists.txt(35): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(58): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(70): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(73): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(85): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(88): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(93): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core: CMakeLists.txt(102): notice: use ${PROJECT_NAME} instead of 'denso_robot_core'
denso_robot_core_test: CMakeLists.txt(24): notice: use ${PROJECT_NAME} instead of 'denso_robot_core_test'
denso_robot_core_test: CMakeLists.txt(27): notice: use ${PROJECT_NAME} instead of 'denso_robot_core_test'
denso_robot_core_test: CMakeLists.txt(35): notice: use ${PROJECT_NAME} instead of 'denso_robot_core_test'
catkin_lint: checked 11 packages and found 53 problems
```
