### PR TITLE
Support xacro

### DIFF
--- a/denso_robot_control/launch/denso_robot_control.launch
+++ b/denso_robot_control/launch/denso_robot_control.launch
@@ -26,7 +26,8 @@
   </include>
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>
+  <!--<param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>-->
+    <param name="robot_description" command="$(find xacro)/xacro '$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf.xacro'"/>
 
   <!-- Controller -->
   <include ns="/$(arg robot_name)" file="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).launch.xml" />

--- a/denso_robot_control/launch/denso_robot_control.launch
+++ b/denso_robot_control/launch/denso_robot_control.launch
@@ -26,8 +26,7 @@
   </include>
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <!--<param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>-->
-    <param name="robot_description" command="$(find xacro)/xacro '$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf.xacro'"/>
+  <param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>
 
   <!-- Controller -->
   <include ns="/$(arg robot_name)" file="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).launch.xml" />

--- a/denso_robot_descriptions/.gitignore
+++ b/denso_robot_descriptions/.gitignore
@@ -1,1 +1,1 @@
-*_description/*
+

--- a/denso_robot_descriptions/vs060_description/vs060.urdf.xacro
+++ b/denso_robot_descriptions/vs060_description/vs060.urdf.xacro
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
+       name="vs060" >
+
+      <xacro:arg name="limited" default="false"/>
+
+  <!-- THE ROBOT -->
+  <link name="world"/>
+
+  <!-- common stuff -->
+  <gazebo>
+    <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_control">
+        <robotNamespace>/vs060</robotNamespace>
+    </plugin>
+  </gazebo>
+
+    <xacro:include filename="$(find denso_robot_descriptions)/vs060_description/vs060_arm.urdf.xacro" />
+    <joint name="joint_w" type="fixed">
+        <parent link = "world" />
+        <child link = "base_link" />
+        <origin xyz="0.00 0.00 0.00" rpy="0.0 0.0 0.0" />
+    </joint>
+    <xacro:vs060 prefix=""/>
+
+</robot>

--- a/denso_robot_descriptions/vs060_description/vs060_arm.urdf.xacro
+++ b/denso_robot_descriptions/vs060_description/vs060_arm.urdf.xacro
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
+    <!--
+    Author: Jin Hirai
+    -->
+
+    <!-- INERTIAL DEFINITION -->
+    <xacro:macro name="upper_triangle_inertial" params="mass *origin">
+        <inertial>
+            <mass value="${mass}"/>
+            <xacro:insert_block name="origin" />
+            <inertia ixx="1" ixy="0" ixz="0"
+                             iyy="1" iyz="0"
+                                     izz="1" />
+        </inertial>
+    </xacro:macro>
+
+    <!-- RECURSIVE LINK -->
+    <xacro:macro name="J" params="prefix num">
+        <link name="${prefix}J${num}">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://denso_robot_descriptions/vs060_description/J${num}.dae" scale="1 1 1" />
+                </geometry>
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://denso_robot_descriptions/vs060_description/J${num}.dae" scale="1 1 1" />
+                </geometry>
+            </collision>
+        <xacro:upper_triangle_inertial mass="1.0">
+            <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        </xacro:upper_triangle_inertial>
+        </link>
+    </xacro:macro>
+
+    <!-- INITIAL JOINT -->
+        <xacro:macro name="init_joint" params="prefix num origin_xyz axis_xyz lim_effort lim_lower lim_upper lim_velocity">
+        <joint name="joint_${prefix}${num}" type="revolute">
+            <parent link="${prefix}base_link" />
+            <child link="${prefix}J${num}" />
+            <origin rpy="0.000000 0.000000 0.000000" xyz="${origin_xyz}" />
+            <axis xyz="${axis_xyz}"/>
+            <limit effort="${lim_effort}" lower="${lim_lower}" upper="${lim_upper}" velocity="${lim_velocity}"/>
+            <dynamics damping="0" friction="0"/>
+        </joint>
+    </xacro:macro>
+
+    <!-- RECURSIVE JOINT -->
+    <xacro:macro name="repeat_joint" params="prefix num origin_xyz axis_xyz lim_effort lim_lower lim_upper lim_velocity">
+        <joint name="joint_${prefix}${num}" type="revolute">
+            <parent link="${prefix}J${num-1}" />
+            <child link="${prefix}J${num}" />
+            <origin rpy="0.000000 0.000000 0.000000" xyz="${origin_xyz}" />
+            <axis xyz="${axis_xyz}"/>
+            <limit effort="${lim_effort}" lower="${lim_lower}" upper="${lim_upper}" velocity="${lim_velocity}"/>
+            <dynamics damping="0" friction="0"/>
+        </joint>
+    </xacro:macro>
+
+    <!-- Gazebo -->
+<!--
+    <xacro:macro name="each_gazebo" params="prefix">
+        <gazebo>
+            <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_control">
+                <robotNamespace>/vs060</robotNamespace>
+            </plugin>
+        </gazebo>
+    </xacro:macro>
+-->
+
+    <!-- TRANSIMISSION DEFINITION -->
+    <xacro:macro name="trans" params="prefix num">
+        <transmission name="trans_${num}">
+            <type>transmission_interface/SimpleTransmission</type>
+            <joint name="joint_${prefix}${num}">
+                <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+            </joint>
+            <actuator name="motor_${num}">
+                <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+                <mechanicalReduction>1</mechanicalReduction>
+            </actuator>
+        </transmission>
+    </xacro:macro>
+
+    <!-- Inertia Params -->
+    <xacro:property name="base_mass" value="1.0"/>
+    <xacro:property name="joint_origin" value="0.000000 0.000000 0.000000"/>
+    <xacro:property name="joint_1_xyz" value="0.000000 0.000000 0.181500"/>
+    <xacro:property name="joint_2_xyz" value="0.000000 0.000000 0.163500"/>
+    <xacro:property name="joint_3_xyz" value="0.000000 0.000000 0.305000"/>
+    <xacro:property name="joint_4_xyz" value="-0.010000 0.000000 0.164500"/>
+    <xacro:property name="joint_5_xyz" value="0.000000 0.000000 0.135500" />
+    <xacro:property name="joint_6_xyz" value="0.000000 0.000000 0.070000" />
+
+    <xacro:property name="axis1" value="-0.000000 -0.000000 1.000000" />
+    <xacro:property name="axis2" value="-0.000000 1.000000 -0.000000" />
+    <xacro:property name="axis3" value="-0.000000 1.000000 -0.000000" />
+    <xacro:property name="axis4" value="-0.000000 -0.000000 1.000000" />
+    <xacro:property name="axis5" value="-0.000000 1.000000 -0.000000" />
+    <xacro:property name="axis6" value="-0.000000 -0.000000 1.000000" />
+
+
+    <xacro:property name="eff1" value="1" /><xacro:property name="eff2" value="1" />
+    <xacro:property name="eff3" value="1" /><xacro:property name="eff4" value="1" />
+    <xacro:property name="eff5" value="1" /><xacro:property name="eff6" value="1" />
+
+
+    <xacro:property name="low1" value="-2.96706" /><xacro:property name="low2" value="-2.094395" />
+    <xacro:property name="low3" value="-2.181662" /><xacro:property name="low4" value="-4.712389" />
+    <xacro:property name="low5" value="-2.094395" /><xacro:property name="low6" value="-6.283185" />
+
+    <xacro:property name="up1" value="2.96706"/><xacro:property name="up2" value="2.094395"/>
+    <xacro:property name="up3" value="2.70526"/><xacro:property name="up4" value="4.712389"/>
+    <xacro:property name="up5" value="2.094395"/><xacro:property name="up6" value="6.283185"/>
+
+    <xacro:property name="vel1" value="3.92699081698724"/><xacro:property name="vel2" value="2.61799387799149"/>
+    <xacro:property name="vel3" value="2.85832571599111"/><xacro:property name="vel4" value="3.92699081698724"/>
+    <xacro:property name="vel5" value="3.02168853397778"/><xacro:property name="vel6" value="6.28318530717959"/>
+
+
+
+    <xacro:macro name="vs060" params="prefix">
+        <link name="${prefix}base_link">
+            <visual>
+                <origin rpy="0 0 0" xyz="0 0 0" />
+                <geometry>
+				    <mesh filename="package://denso_robot_descriptions/vs060_description/base_link.dae" scale="1 1 1" />
+			    </geometry>
+            </visual>
+            <collision>
+                <origin rpy="0 0 0" xyz="0 0 0" />
+                <geometry>
+                    <mesh filename="package://denso_robot_descriptions/vs060_description/base_link.dae" scale="1 1 1" />
+                </geometry>
+            </collision>
+            <xacro:upper_triangle_inertial mass="${base_mass}">
+                <origin rpy="0.000000 0.000000 0.000000" xyz="1.000000 0.000000 0.000000" />
+            </xacro:upper_triangle_inertial>
+        </link>
+
+        <!--<xacro:each_gazebo prefix="${prefix}"/>-->
+        <xacro:J prefix="${prefix}" num="1"/>
+        <xacro:init_joint prefix="${prefix}" num="1" origin_xyz="${joint_1_xyz}" axis_xyz="${axis1}"
+                         lim_effort="${eff1}" lim_lower="${low1}" lim_upper="${up1}" lim_velocity="${vel1}"/>
+        <xacro:trans prefix="${prefix}" num="1"/>
+
+        <!-- Definition of link -->
+        <xacro:J prefix="${prefix}" num="2"/>
+        <xacro:repeat_joint prefix="${prefix}" num="2" origin_xyz="${joint_2_xyz}" axis_xyz="${axis2}"
+                         lim_effort="${eff2}" lim_lower="${low2}" lim_upper="${up2}" lim_velocity="${vel2}"/>
+        <xacro:trans prefix="${prefix}" num="2"/>
+
+
+        <xacro:J prefix="${prefix}" num="3"/>
+        <xacro:repeat_joint prefix="${prefix}" num="3" origin_xyz="${joint_3_xyz}" axis_xyz="${axis3}"
+                         lim_effort="${eff3}" lim_lower="${low3}" lim_upper="${up3}" lim_velocity="${vel3}"/>
+        <xacro:trans prefix="${prefix}" num="3"/>
+
+        <xacro:J prefix="${prefix}" num="4"/>
+        <xacro:repeat_joint prefix="${prefix}" num="4" origin_xyz="${joint_4_xyz}" axis_xyz="${axis4}"
+                         lim_effort="${eff4}" lim_lower="${low4}" lim_upper="${up4}" lim_velocity="${vel4}"/>
+        <xacro:trans prefix="${prefix}" num="4"/>
+
+        <xacro:J prefix="${prefix}" num="5"/>
+        <xacro:repeat_joint prefix="${prefix}" num="5" origin_xyz="${joint_5_xyz}" axis_xyz="${axis5}"
+                         lim_effort="${eff5}" lim_lower="${low5}" lim_upper="${up5}" lim_velocity="${vel5}"/>
+        <xacro:trans prefix="${prefix}" num="5"/>
+
+        <xacro:J prefix="${prefix}" num="6"/>
+        <xacro:repeat_joint prefix="${prefix}" num="6" origin_xyz="${joint_6_xyz}" axis_xyz="${axis6}"
+                         lim_effort="${eff6}" lim_lower="${low6}" lim_upper="${up6}" lim_velocity="${vel6}"/>
+        <xacro:trans prefix="${prefix}" num="6"/>
+    </xacro:macro>
+</robot>

--- a/denso_robot_gazebo/launch/denso_robot_gazebo.launch
+++ b/denso_robot_gazebo/launch/denso_robot_gazebo.launch
@@ -10,7 +10,8 @@
   </include>
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>
+  <!--<param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>-->
+  <param name="robot_description" command="$(find xacro)/xacro '$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf.xacro'"/>
 
   <arg name="gui" default="true"/>
   <param name="use_gui" value="$(arg gui)"/>

--- a/denso_robot_gazebo/launch/denso_robot_gazebo.launch
+++ b/denso_robot_gazebo/launch/denso_robot_gazebo.launch
@@ -10,8 +10,7 @@
   </include>
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <!--<param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>-->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf.xacro'"/>
+  <param name="robot_description" type="str" textfile="$(find denso_robot_descriptions)/$(arg robot_description)/$(arg robot_name).urdf"/>
 
   <arg name="gui" default="true"/>
   <param name="use_gui" value="$(arg gui)"/>

--- a/denso_robot_moveit_config/launch/planning_context.launch
+++ b/denso_robot_moveit_config/launch/planning_context.launch
@@ -9,7 +9,9 @@
   <arg name="robot_name" default="vs060"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find denso_robot_descriptions)/$(arg robot_name)_description/$(arg robot_name).urdf"/>
+  <!--<param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find denso_robot_descriptions)/$(arg robot_name)_description/$(arg robot_name).urdf"/>-->
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)"
+         command="$(find xacro)/xacro '$(find denso_robot_descriptions)/$(arg robot_name)_description/$(arg robot_name).urdf.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find denso_robot_moveit_config)/config/$(arg robot_name)_config/$(arg robot_name).srdf" />

--- a/denso_robot_moveit_config/launch/planning_context.launch
+++ b/denso_robot_moveit_config/launch/planning_context.launch
@@ -9,9 +9,7 @@
   <arg name="robot_name" default="vs060"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <!--<param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find denso_robot_descriptions)/$(arg robot_name)_description/$(arg robot_name).urdf"/>-->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)"
-         command="$(find xacro)/xacro '$(find denso_robot_descriptions)/$(arg robot_name)_description/$(arg robot_name).urdf.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find denso_robot_descriptions)/$(arg robot_name)_description/$(arg robot_name).urdf"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find denso_robot_moveit_config)/config/$(arg robot_name)_config/$(arg robot_name).srdf" />


### PR DESCRIPTION
VS060 arm is now compatible with xacro.
When applying the vs060 arm, various parts may be combined such as a dolly or an end-effector.
Therefore, it would be difficult to simulate on Gazebo with only a single existing urdf file.Thus, the xacro file has been created to make it easier to extend the simulation in the future. This usage uses `vs060_arm.urdf.xacro` as a macro, so we call the above macro in `vs060.urdf.xacro` to create an entity.

Please use the following command to see if the URDF can be generated from XACRO correctly.
```
$ rosrun xacro xacro vs060.urdf.xacro > tmp.urdf
$ check_urdf tmp.urdf 
```
If it succeeds in generating it, you should get the following output.
```
robot name is: vs060
---------- Successfully Parsed XML ---------------
root Link: world has 1 child(ren)
    child(1):  base_link
        child(1):  J1
            child(1):  J2
                child(1):  J3
                    child(1):  J4
                        child(1):  J5
                            child(1):  J6

```

There may be other files that need to be changed if you call URDF, but please refer to the commit history and change them.
 
It would be nice if these pull requests could be merged. Thank you!
